### PR TITLE
feat(minimum-config): add minimumConfig and onTouchBegin

### DIFF
--- a/exampleExpo/src/pages/normal/index.tsx
+++ b/exampleExpo/src/pages/normal/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { ScrollView } from "react-native-gesture-handler";
-import type { ICarouselInstance } from "react-native-reanimated-carousel";
+import type { ICarouselInstance, TCarouselProps } from "react-native-reanimated-carousel";
 import Carousel from "react-native-reanimated-carousel";
 import { SafeAreaView } from "react-native-safe-area-context";
 
@@ -16,6 +16,7 @@ function Index() {
   const [isFast, setIsFast] = React.useState(false);
   const [isAutoPlay, setIsAutoPlay] = React.useState(false);
   const [isPagingEnabled, setIsPagingEnabled] = React.useState(true);
+  const [minimumConfig, setMinimumConfig] = React.useState<TCarouselProps["minimumConfig"]>();
   const ref = React.useRef<ICarouselInstance>(null);
 
   const baseOptions = isVertical
@@ -40,6 +41,7 @@ function Index() {
         style={{ width: "100%" }}
         autoPlay={isAutoPlay}
         autoPlayInterval={isFast ? 100 : 2000}
+        minimumConfig={minimumConfig}
         data={data}
         pagingEnabled={isPagingEnabled}
         onSnapToItem={index => console.log("current index:", index)}
@@ -79,7 +81,7 @@ function Index() {
             setIsPagingEnabled(!isPagingEnabled);
           }}
         >
-                PagingEnabled:{isPagingEnabled.toString()}
+          PagingEnabled:{isPagingEnabled.toString()}
         </SButton>
         <SButton
           onPress={() => {
@@ -93,7 +95,7 @@ function Index() {
             console.log(ref.current?.getCurrentIndex());
           }}
         >
-                Log current index
+          Log current index
         </SButton>
         <SButton
           onPress={() => {
@@ -104,21 +106,36 @@ function Index() {
             );
           }}
         >
-                Change data length to:{data.length === 6 ? 8 : 6}
+          Change data length to:{data.length === 6 ? 8 : 6}
         </SButton>
         <SButton
           onPress={() => {
             ref.current?.scrollTo({ count: -1, animated: true });
           }}
         >
-                prev
+          prev
         </SButton>
         <SButton
           onPress={() => {
             ref.current?.scrollTo({ count: 1, animated: true });
           }}
         >
-                next
+          next
+        </SButton>
+        <SButton
+          onPress={() => {
+            if (minimumConfig) {
+              setMinimumConfig(undefined);
+            }
+            else {
+              setMinimumConfig({
+                minimumScrollDistancePerSwipe: PAGE_WIDTH / 2,
+                minimumScrollVelocity: 1000,
+              });
+            }
+          }}
+        >
+          Minimum config: {minimumConfig ? "enabled" : "disabled"}
         </SButton>
       </ScrollView>
     </SafeAreaView>

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -50,6 +50,7 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
       onSnapToItem,
       onScrollBegin,
       onProgressChange,
+      onTouchBegin,
       customAnimation,
       defaultIndex,
     } = props;
@@ -134,9 +135,10 @@ const Carousel = React.forwardRef<ICarouselInstance, TCarouselProps<any>>(
       _onScrollEnd();
     }, [_onScrollEnd, startAutoPlay]);
 
-    const scrollViewGestureOnTouchBegin = React.useCallback(pauseAutoPlay, [
-      pauseAutoPlay,
-    ]);
+    const scrollViewGestureOnTouchBegin = React.useCallback(() => {
+      pauseAutoPlay();
+      onTouchBegin?.();
+    }, [pauseAutoPlay, onTouchBegin]);
 
     const scrollViewGestureOnTouchEnd = React.useCallback(startAutoPlay, [
       startAutoPlay,

--- a/src/ScrollViewGesture.tsx
+++ b/src/ScrollViewGesture.tsx
@@ -52,6 +52,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
       dataLength,
       overscrollEnabled,
       maxScrollDistancePerSwipe,
+      minimumConfig,
     },
   } = React.useContext(CTX);
 
@@ -323,6 +324,21 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
           const nextPage = Math.round((ctx.panOffset + maxScrollDistancePerSwipe * Math.sign(totalTranslation)) / size) * size;
           translation.value = withSpring(withProcessTranslation(nextPage), onScrollEnd);
         }
+        // If minimumConfig is provided, use it to determine if the swipe is valid
+        else if (minimumConfig) {
+          const { minimumScrollDistancePerSwipe, minimumScrollVelocity } = minimumConfig;
+
+          const isSwipeValid = Math.abs(totalTranslation) > minimumScrollDistancePerSwipe
+            || Math.abs(scrollEndVelocity.value) > minimumScrollVelocity;
+
+          if (isSwipeValid) { endWithSpring(onScrollEnd); }
+
+          else {
+            const closestPage = Math.round(ctx.panOffset / size) * size;
+            translation.value = withSpring(closestPage, onScrollEnd);
+          }
+        }
+
         else {
           endWithSpring(onScrollEnd);
         }
@@ -340,6 +356,7 @@ const IScrollViewGesture: React.FC<PropsWithChildren<Props>> = (props) => {
       snapEnabled,
       onScrollBegin,
       onScrollEnd,
+      minimumConfig,
     ],
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,18 @@ export type TCarouselProps<T = any> = {
     absoluteProgress: number
   ) => void
 
+  /**
+   * Config for setting
+   * minimumScrollDistancePerSwipe = Minimum amount of pixels needed to scroll to the next item
+   * minimumScrollVelocity = Minimum velocity needed to scroll to the next item
+   */
+  minimumConfig?: {
+    minimumScrollDistancePerSwipe: number
+    minimumScrollVelocity: number
+  }
+
+  onTouchBegin?: () => void
+
   // ============================== deprecated props ==============================
   /**
      * If enabled, releasing the touch will scroll to the nearest item.


### PR DESCRIPTION
## What 
Added two props to `Carousel.tsx`:
* `minimumConfig?: {
    minimumScrollDistancePerSwipe: number
    minimumScrollVelocity: number
  }`
* `onTouchBegin?: () => void`

## How

* The `onTouchBegin` callback is optionally called on the the ScrollViews `onTouchBegin`
* minimumConfig is used in the `onEnd` callback in `ScrollViewGesture.tsx`. If provided, a minumum pixel and velocity threshold will be checked on the end of a gesture.

## Why

* `onTouchBegin` is needed to allow capturing the first touch without triggering on any `next` function.
* minimumConfig is used to improve the feel of the carousel, to make sure that a gesture does not automatically lead to a swipe.
